### PR TITLE
refactor JENKINS_URL setting and add tests

### DIFF
--- a/helga_jenkins.py
+++ b/helga_jenkins.py
@@ -4,6 +4,11 @@ from jenkins import Jenkins, JenkinsException
 
 logger = log.getLogger(__name__)
 
+def get_jenkins_url(settings):
+    url = getattr(settings, 'JENKINS_URL', None)
+    if not url:
+        raise RuntimeError('no JENKINS_URL is configured, cannot continue')
+    return url
 
 def status(conn, name, *args):
     logger.debug('user requested name: %s' % name)
@@ -151,9 +156,7 @@ def connect(nick):
     If no authentication is configured, just a connection is returned with no
     authentication (probably read-only, depending on Jenkins settings)
     """
-    url = getattr(settings, 'JENKINS_URL')
-    if not url:
-        raise RuntimeError('no JENKINS_URL is configured, cannot continue')
+    url = get_jenkins_url(settings)
     username = getattr(settings, 'JENKINS_USERNAME', None)
     password = getattr(settings, 'JENKINS_PASSWORD', None)
     credentials = getattr(settings, 'JENKINS_CREDENTIALS', {})

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -1,0 +1,17 @@
+from helga_jenkins import get_jenkins_url
+import pytest
+
+class FakeSettings(object):
+    pass
+
+class TestSettings(object):
+    def test_missing_jenkins_url(self):
+        settings = FakeSettings()
+        with pytest.raises(RuntimeError):
+            result = get_jenkins_url(settings)
+
+    def test_jenkins_url(self):
+        settings = FakeSettings()
+        settings.JENKINS_URL = 'http://jenkins.example.com/'
+        result = get_jenkins_url(settings)
+        assert result == 'http://jenkins.example.com/'


### PR DESCRIPTION
Prior to this change, a missing `JENKINS_URL` setting would raise a `AttributeError` instead of a `RuntimeError` because we were not specifying a "`None`" default to `getattr()`

Refactor the `JENKINS_URL` setting logic into its own function, and add unit tests.