### PR TITLE
README.rst: fix rST syntax in hyperlink

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Successful runs will also report back to the user::
 Installation
 ------------
 This Jenkins plugin is `available from PyPI
-<https://pypi.python.org/pypi/helga-jenkins`_, so you can simply install it
+<https://pypi.python.org/pypi/helga-jenkins>`_, so you can simply install it
 with ``pip``::
 
   pip install helga-jenkins


### PR DESCRIPTION
This was causing README.rst to display incorrectly on PyPI.