### PR TITLE
catch HTTPError

### DIFF
--- a/helga_jenkins.py
+++ b/helga_jenkins.py
@@ -370,7 +370,7 @@ def helga_jenkins(client, channel, nick, message, cmd, args):
         return 'need more arguments for sub command: %s' % sub_command
     try:
         return sub_commands[sub_command](conn, *args, client=client, channel=channel, nick=nick)
-    except (JenkinsException, RuntimeError) as error:
+    except (JenkinsException, HTTPError, RuntimeError) as error:
         return str(error)
     except KeyError:
         if sub_command == 'help':


### PR DESCRIPTION
This jenkins call can sometimes raise an HTTPError from urllib2.

The full traceback was:
```
Traceback (most recent call last):
  File
"/opt/helga/lib/python2.7/site-packages/helga/plugins/__init__.py", line
327, in process
    resp = plugin.process(client, channel, nick, message)
  File
"/opt/helga/lib/python2.7/site-packages/helga/plugins/__init__.py", line
619, in process
    return self.run(client, channel, nick, message, command, args)
  File "/opt/helga/src/helga-jenkins/helga_jenkins.py", line 372, in
helga_jenkins
    return sub_commands[sub_command](conn, *args, client=client,
channel=channel, nick=nick)
  File "/opt/helga/src/helga-jenkins/helga_jenkins.py", line 180, in
build
    jenkins_conn.build_job(name, parameters=params,
token=jenkins_conn.password)
  File "/opt/helga/lib/python2.7/site-packages/jenkins/__init__.py",
line 654, in build_job
    self.build_job_url(name, parameters, token), b''))
  File "/opt/helga/lib/python2.7/site-packages/jenkins/__init__.py",
line 280, in jenkins_open
    response = urlopen(req, timeout=self.timeout).read()
  File "/usr/lib64/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 410, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 523, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 448, in error
    return self._call_chain(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 531, in
http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
```