### PR TITLE
import urllib2's HTTPError

### DIFF
--- a/helga_jenkins.py
+++ b/helga_jenkins.py
@@ -2,6 +2,7 @@ from twisted.internet import reactor
 from helga.plugins import command, ResponseNotReady
 from helga import log, settings
 from jenkins import Jenkins, JenkinsException, NotFoundException
+from urllib2 import HTTPError
 
 logger = log.getLogger(__name__)
 


### PR DESCRIPTION
3844b1ebd5a585a267b3c54d9751de0d81706ea9 uses HTTPError, but we don't import that before using it.

Import it here.
