### PR TITLE
build: correct jenkins_conn name

### DIFF
--- a/helga_jenkins.py
+++ b/helga_jenkins.py
@@ -203,7 +203,7 @@ def build(jenkins_conn, *args, **kw):
     args = list(args)
     args.pop(0)  # get rid of the command
     name = get_name(jenkins_conn, args.pop(0))
-    info = conn.get_job_info(name)
+    info = jenkins_conn.get_job_info(name)
 
     next_build_number = info['nextBuildNumber']
 


### PR DESCRIPTION
In this `build()` function, the Jenkins connection object is "jenkins_conn", not "conn".

Fixes the following crash:

```
  File
"/opt/helga/lib/python2.7/site-packages/helga/plugins/__init__.py", line
327, in process
    resp = plugin.process(client, channel, nick, message)
  File
"/opt/helga/lib/python2.7/site-packages/helga/plugins/__init__.py", line
619, in process
    return self.run(client, channel, nick, message, command, args)
  File "/opt/helga/src/helga-jenkins/helga_jenkins.py", line 404, in
helga_jenkins
    return sub_commands[sub_command](conn, *args, client=client,
channel=channel, nick=nick)
  File "/opt/helga/src/helga-jenkins/helga_jenkins.py", line 207, in
build
    info = conn.get_job_info(name)
NameError: global name 'conn' is not defined
```
